### PR TITLE
Updated mdistance to return appropriate error.

### DIFF
--- a/src/extension-sorressean.cc
+++ b/src/extension-sorressean.cc
@@ -519,7 +519,7 @@ bf_mdistance(Var arglist, Byte next, void *vdata, Objid progr)
             if (arglist.v.list[2].v.list[index].type != TYPE_LIST)    
             {
                     free_var(arglist);
-                    return make_error_pack(E_RANGE);
+                    return make_error_pack(E_TYPE);
                 }
       
      if (arglist.v.list[2].v.list[index].v.list[0].v.num < 3)


### PR DESCRIPTION
An addendum to b7840bbe890c0be693d0af88c2681a429f554050 -- 
Updates the mdistance function to return E_TYPE rather than E_RANGE during argument validation.