### PR TITLE
Curl

### DIFF
--- a/src/curl.cc
+++ b/src/curl.cc
@@ -15,7 +15,7 @@ static CURL *curl_handle = nullptr;
 typedef struct CurlMemoryStruct {
     char *result;
     size_t size;
-} CurlMemoryStruct;
+};
 
 static size_t
 CurlWriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
@@ -68,6 +68,7 @@ void curl_thread_callback(Var arglist, Var *ret)
     }
 
     curl_easy_cleanup(curl_handle);
+    free_var(arglist);
     free(chunk.result);
 }
 
@@ -75,7 +76,10 @@ static package
 bf_curl(Var arglist, Byte next, void *vdata, Objid progr)
 {
     if (!is_wizard(progr))
+    {
+        free_var(arglist);
         return make_error_pack(E_PERM);
+    }
 
     char *human_string = nullptr;
     asprintf(&human_string, "curl %s", arglist.v.list[1].v.str);

--- a/src/curl.cc
+++ b/src/curl.cc
@@ -40,23 +40,18 @@ CurlWriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
 
 void curl_thread_callback(Var arglist, Var *ret)
 {
-    int nargs = arglist.v.list[0].v.num;
-    CURL *curl_handle;
     CURLcode res;
     CurlMemoryStruct chunk;
 
     chunk.result = (char*)malloc(1);
     chunk.size = 0;
 
-    curl_handle = curl_easy_init();
     curl_easy_setopt(curl_handle, CURLOPT_URL, arglist.v.list[1].v.str);
     curl_easy_setopt(curl_handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
     curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, CurlWriteMemoryCallback);
     curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
     curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
 
-    if (nargs > 1 && is_true(arglist.v.list[2]))
-        curl_easy_setopt(curl_handle, CURLOPT_HEADER, 1L);
 
     res = curl_easy_perform(curl_handle);
 
@@ -73,7 +68,7 @@ void curl_thread_callback(Var arglist, Var *ret)
 }
 
 static package
-bf_curl(Var arglist, Byte next, void *vdata, Objid progr)
+bf_curl_get(Var arglist, Byte next, void *vdata, Objid progr)
 {
     if (!is_wizard(progr))
     {
@@ -81,7 +76,35 @@ bf_curl(Var arglist, Byte next, void *vdata, Objid progr)
         return make_error_pack(E_PERM);
     }
 
+    curl_handle = curl_easy_init();
     char *human_string = nullptr;
+    asprintf(&human_string, "curl %s", arglist.v.list[1].v.str);
+
+    if (arglist.v.list[0].v.num > 1 && is_true(arglist.v.list[2]))
+        curl_easy_setopt(curl_handle, CURLOPT_HEADER, 1L);
+
+    return background_thread(curl_thread_callback, &arglist, human_string);
+}
+
+
+static package
+bf_curl_post(Var arglist, Byte next, void *vdata, Objid progr)
+{
+    if (!is_wizard(progr))
+    {
+        free_var(arglist);
+        return make_error_pack(E_PERM);
+    }
+
+    curl_handle = curl_easy_init();
+    char *human_string = nullptr;
+    const char *data = arglist.v.list[2].v.str;
+
+    if (arglist.v.list[0].v.num > 2 && is_true(arglist.v.list[3]))
+        curl_easy_setopt(curl_handle, CURLOPT_HEADER, 1L);
+
+    curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDSIZE, (long) strlen(data));
+    curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS, data);
     asprintf(&human_string, "curl %s", arglist.v.list[1].v.str);
 
     return background_thread(curl_thread_callback, &arglist, human_string);
@@ -145,8 +168,9 @@ register_curl(void)
     oklog("REGISTER_CURL: Using libcurl version %s\n", curl_version());
     curl_global_init(CURL_GLOBAL_ALL);
     curl_handle = curl_easy_init();
- 
-   register_function("curl", 1, 2, bf_curl, TYPE_STR, TYPE_ANY);
+
+    register_function("curl_get", 1, 2, bf_curl_get, TYPE_STR, TYPE_ANY);
+    register_function("curl_post", 2, 3, bf_curl_post, TYPE_STR, TYPE_STR, TYPE_ANY);
     register_function("url_encode", 1, 1, bf_url_encode, TYPE_STR);
     register_function("url_decode", 1, 1, bf_url_decode, TYPE_STR);
 }

--- a/src/extension-sorressean.cc
+++ b/src/extension-sorressean.cc
@@ -519,7 +519,7 @@ bf_mdistance(Var arglist, Byte next, void *vdata, Objid progr)
             if (arglist.v.list[2].v.list[index].type != TYPE_LIST)    
             {
                     free_var(arglist);
-                    return make_error_pack(E_RANGE);
+                    return make_error_pack(E_TYPE);
                 }
       
      if (arglist.v.list[2].v.list[index].v.list[0].v.num < 3)


### PR DESCRIPTION
## COMPATIBILITY Warning: 
  In order to lay down the groundwork for expanding functionality, I felt it was prudent to explicitly communicate function (or purpose). Thus previously known curl is now *curl_get*. This means that previous calls to curl will just lead to heartbreak.

###  curl_get
- Operates exactly like curl. It accepts the usual arguments: curl_get(STR *URL*[, BOOL *headers*])

### curl_post
- Accepts 3-4 arguments: curl_post(STR *URL*, STR *data*[, BOOL *headers*]) -- Where *data* holds (usually in json format) the value of your post.
